### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # FFmpeg-MCP
 Using ffmpeg command line to achieve an mcp server, can be very convenient, through the dialogue to achieve the local video search, tailoring, stitching, playback and other functions
 
+<a href="https://glama.ai/mcp/servers/@video-creator/ffmpeg-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@video-creator/ffmpeg-mcp/badge" alt="FFmpeg-Server MCP server" />
+</a>
+
 ## Support Tools
 The server implements the following tools: <br/>
 - `find_video_path`


### PR DESCRIPTION
This PR adds a badge for the [FFmpeg-MCP Server](https://glama.ai/mcp/servers/@video-creator/ffmpeg-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@video-creator/ffmpeg-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@video-creator/ffmpeg-mcp/badge" alt="FFmpeg-Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.